### PR TITLE
feat(archives): Update configuration and add category/tag archives

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,4 +34,3 @@ gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
 
 gem "jekyll-include-cache", group: :jekyll_plugins
 gem "minimal-mistakes-jekyll"
-gem "jekyll-archives"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,8 +128,6 @@ GEM
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
       webrick (>= 1.0)
-    jekyll-archives (2.3.0)
-      jekyll (>= 3.6, < 5.0)
     jekyll-avatar (0.8.0)
       jekyll (>= 3.0, < 5.0)
     jekyll-coffeescript (1.2.2)
@@ -313,7 +311,6 @@ PLATFORMS
 DEPENDENCIES
   github-pages (~> 232)
   http_parser.rb (~> 0.6.0)
-  jekyll-archives
   jekyll-feed (~> 0.12)
   jekyll-include-cache
   minima (~> 2.5)

--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ repository               : "rnaufal/rnaufal.github.io"
 teaser                   : # path of fallback teaser image, e.g. "/assets/images/500x300.png"
 logo                     : # path of logo image to display in the masthead, e.g. "/assets/images/88x88.png"
 masthead_title           : # overrides the website title displayed in the masthead, use " " for no title
-breadcrumbs              : # true, false (default)
+breadcrumbs              : false
 words_per_minute         : 200
 enable_copy_code_button  : # true, false (default)
 copyright                : # "copyright" name, defaults to site.title
@@ -223,6 +223,10 @@ sass:
 permalink: /:year/:month/:day/:title.html
 timezone: # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 
+permalinks:
+  category: /categories/:name/
+  tag: /tags/:name/
+
 
 # Pagination with jekyll-paginate
 paginate: 5 # amount of posts to show
@@ -258,7 +262,6 @@ plugins:
   - jekyll-feed
   - jekyll-include-cache
   - jekyll-seo-tag
-  - jekyll-archives
 
 # mimic GitHub Pages with --safe
 whitelist:
@@ -268,7 +271,6 @@ whitelist:
   - jekyll-feed
   - jekyll-include-cache
   - jekyll-seo-tag
-  - jekyll-archives
 
 
 # Archives
@@ -287,19 +289,6 @@ category_archive:
 tag_archive:
   type: liquid
   path: /tags/
-
-# https://github.com/jekyll/jekyll-archives
-jekyll-archives:
-  enabled:
-    - categories
-    - tags
-  layouts:
-    category: category
-    tag: tag
-  permalinks:
-    category: /categories/:name/
-    tag: /tags/:name/
-
 
 # HTML Compression
 # - https://jch.penibelst.de/

--- a/_pages/category-archive.md
+++ b/_pages/category-archive.md
@@ -1,0 +1,6 @@
+---
+title: "Posts by Category"
+layout: categories
+permalink: /categories/
+author_profile: true
+---

--- a/_pages/index.html
+++ b/_pages/index.html
@@ -1,5 +1,0 @@
----
-layout: single
-pagination:
-  enabled: true
----

--- a/_pages/tag-archive.md
+++ b/_pages/tag-archive.md
@@ -1,0 +1,6 @@
+---
+title: "Posts by Tag"
+permalink: /tags/
+layout: tags
+author_profile: true
+---


### PR DESCRIPTION
This pull request includes changes to the `Gemfile` and `_config.yml` to remove the `jekyll-archives` plugin, as well as updates to other configuration settings and the addition of new pages for category and tag archives.

### Removal of `jekyll-archives` plugin:

* [`Gemfile`](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fL37): Removed the `jekyll-archives` gem.
* [`_config.yml`](diffhunk://#diff-ecec67b0e1d7e17a83587c6d27b6baaaa133f42482b07bd3685c77f34b62d883L261): Removed `jekyll-archives` from the `plugins` and `whitelist` sections. [[1]](diffhunk://#diff-ecec67b0e1d7e17a83587c6d27b6baaaa133f42482b07bd3685c77f34b62d883L261) [[2]](diffhunk://#diff-ecec67b0e1d7e17a83587c6d27b6baaaa133f42482b07bd3685c77f34b62d883L271)
* [`_config.yml`](diffhunk://#diff-ecec67b0e1d7e17a83587c6d27b6baaaa133f42482b07bd3685c77f34b62d883L291-L303): Removed the `jekyll-archives` configuration block.

### Configuration updates:

* [`_config.yml`](diffhunk://#diff-ecec67b0e1d7e17a83587c6d27b6baaaa133f42482b07bd3685c77f34b62d883L31-R31): Set `breadcrumbs` to `false`.
* [`_config.yml`](diffhunk://#diff-ecec67b0e1d7e17a83587c6d27b6baaaa133f42482b07bd3685c77f34b62d883R226-R229): Added `permalinks` configuration for categories and tags.

### Addition of new pages:

* [`_pages/category-archive.md`](diffhunk://#diff-cda6c843f48f8d88e8d4b9e0c29f8be3d3f9fb45d19dd7e65c503df7c16a3bbbR1-R6): Added a new page for category archives with appropriate front matter.
* [`_pages/tag-archive.md`](diffhunk://#diff-c927e15d529e4bfec09344764192fef39e54ea1b16498a54138981bac17ad3a1R1-R6): Added a new page for tag archives with appropriate front matter.

### Removal of pagination configuration:

* [`_pages/index.html`](diffhunk://#diff-3c11b02a7fc769c79f176cf98511d7c1f59a2dc9b036e62d5ccbe1b2819fc855L1-L5): Removed pagination configuration from the index page.