### PR TITLE
feat(navigation): Add main navigation structure with links to Home, About, Posts, Categories, and Tags

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,0 +1,16 @@
+main:
+  - title: "Home"
+    url: /
+    tooltip: "Home"
+  - title: "About"
+    url: /about/
+    tooltip: "About"
+  - title: "Posts"
+    url: /year-archive/
+    tooltip: "Posts"
+  - title: "Categories"
+    url: /categories/
+    tooltip: "Categories"
+  - title: "Tags"
+    url: /tags/
+    tooltip: "Tags"


### PR DESCRIPTION
This pull request includes changes to the `_data/navigation.yml` file to add a main navigation menu to the website. The most important changes include adding navigation items for Home, About, Posts, Categories, and Tags.

Navigation menu additions:

* Added "Home" navigation item with URL `/` and tooltip "Home".
* Added "About" navigation item with URL `/about/` and tooltip "About".
* Added "Posts" navigation item with URL `/year-archive/` and tooltip "Posts".
* Added "Categories" navigation item with URL `/categories/` and tooltip "Categories".
* Added "Tags" navigation item with URL `/tags/` and tooltip "Tags".