### PR TITLE
fix(docs): Clean up markdown formatting and remove unnecessary elements

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -70,7 +70,7 @@ atom_feed:
   hide                   : # true, false (default)
 search                   : true
 search_full_content      : false
-search_provider          : lunr
+search_provider          : "lunr"
 lunr:
   search_within_pages    : true
 algolia:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -14,6 +14,3 @@ main:
   - title: "Tags"
     url: /tags/
     tooltip: "Tags"
-  - title: "Search"
-    url: /search/
-    tooltip: "Search"

--- a/_pages/search.md
+++ b/_pages/search.md
@@ -1,5 +1,0 @@
----
-title: Search
-layout: search
-permalink: /search/
----

--- a/_posts/2007-11-29-testsuite-merlin-javadoc.md
+++ b/_posts/2007-11-29-testsuite-merlin-javadoc.md
@@ -20,5 +20,3 @@ tags:
 ---
 
 Running through the [Java](http://java.sun.com) [TestSuite](http://junit.sourceforge.net/javadoc/junit/framework/TestSuite.html) API I’ve found this funny [javadoc](http://java.sun.com/j2se/javadoc)..
-
-<div style="text-align:center;">![](http://br.geocities.com/rsilvasp/funny_javadoc.jpg)</div>

--- a/_posts/2008-01-13-effective-java-programming-with-joshua-bloch.md
+++ b/_posts/2008-01-13-effective-java-programming-with-joshua-bloch.md
@@ -22,5 +22,3 @@ tags:
 Nice video from [Joshua Block](http://en.wikipedia.org/wiki/Joshua_Bloch), Chief Java Architect at Google, talking about his Effective Java™ Programming Language Guide book and also about the consequences of adding new features on the [Java](http://java.sun.com/) language, like the closures’ proposals. He also offers an advice to the programmers, when designing [API’s](http://en.wikipedia.org/wiki/API), classes or methods:
 
 > “When in doubt, leave it out”.
-
-<div style="text-align:center;"></div>


### PR DESCRIPTION
This pull request includes changes to improve the configuration of the search functionality, remove unused search-related pages, and clean up outdated or unnecessary content in blog posts. Below is a summary of the most important changes:

### Search functionality updates:

* Updated the `search_provider` value in `_config.yml` to explicitly use a string for "lunr" to ensure compatibility with YAML parsing. (`[_config.ymlL73-R73](diffhunk://#diff-ecec67b0e1d7e17a83587c6d27b6baaaa133f42482b07bd3685c77f34b62d883L73-R73)`)

### Removal of unused search-related pages:

* Removed the "Search" entry from the navigation menu in `_data/navigation.yml`. (`[_data/navigation.ymlL17-L19](diffhunk://#diff-f8949f06b04d9d8da89c490e107e04dba06c3e06fbb9000b46192062437ac187L17-L19)`)
* Deleted the `_pages/search.md` file, which previously defined the search page layout and permalink. (`[_pages/search.mdL1-L5](diffhunk://#diff-1d02da2ff667c7b3b6f016626a3009de4c355f381dce58287e805784d1cddeb9L1-L5)`)

### Cleanup of outdated blog post content:

* Removed a broken image link from the blog post `_posts/2007-11-29-testsuite-merlin-javadoc.md`. (`[_posts/2007-11-29-testsuite-merlin-javadoc.mdL23-L24](diffhunk://#diff-215a8446da6c7ad4344d150119679a040754d7460af26c4a40c980916e4e59bdL23-L24)`)
* Removed an empty `<div>` tag from the blog post `_posts/2008-01-13-effective-java-programming-with-joshua-bloch.md`. (`[_posts/2008-01-13-effective-java-programming-with-joshua-bloch.mdL25-L26](diffhunk://#diff-6d2edc3e399969b7650ea94d389dbe69dad034881b1cec92a314ca3532f3f57dL25-L26)`)