### PR TITLE
fix(permalinks): Update permalink structure for 404 page and config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -221,7 +221,7 @@ sass:
 
 
 # Outputting
-permalink: /:year/:month/:day/:title
+permalink: /:year/:month/:day/:title/
 timezone: # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 
 permalinks:

--- a/_config.yml
+++ b/_config.yml
@@ -221,7 +221,7 @@ sass:
 
 
 # Outputting
-permalink: /:year/:month/:day/:title.html
+permalink: /:year/:month/:day/:title
 timezone: # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 
 permalinks:

--- a/_pages/404.md
+++ b/_pages/404.md
@@ -2,7 +2,7 @@
 title: "Page Not Found"
 excerpt: "Page not found. Your pixels are in another canvas."
 sitemap: false
-permalink: /404.html
+permalink: /404
 ---
 
 Sorry, but the page you were trying to view does not exist.

--- a/_pages/404.md
+++ b/_pages/404.md
@@ -2,7 +2,7 @@
 title: "Page Not Found"
 excerpt: "Page not found. Your pixels are in another canvas."
 sitemap: false
-permalink: /404
+permalink: /404/
 ---
 
 Sorry, but the page you were trying to view does not exist.


### PR DESCRIPTION
This pull request updates permalink structures across the project to remove `.html` extensions from URLs, ensuring cleaner and more user-friendly URLs.

Permalink structure updates:

* [`_config.yml`](diffhunk://#diff-ecec67b0e1d7e17a83587c6d27b6baaaa133f42482b07bd3685c77f34b62d883L224-R224): Changed the `permalink` format to remove `.html` extensions from URLs in the site's configuration.
* [`_pages/404.md`](diffhunk://#diff-649b828639a61275f5fbd75872c0323faaaa373db3cb87c3a09dea7cb85bec60L5-R5): Updated the permalink for the 404 error page to remove the `.html` extension.