### PR TITLE
chore(docs): Remove outdated date entries from multiple markdown files

### DIFF
--- a/_drafts/Auto-Draft.md
+++ b/_drafts/Auto-Draft.md
@@ -1,7 +1,6 @@
 ---
 id: 753
 title: 'Auto Draft'
-date: '2024-11-21T20:20:13-03:00'
 layout: posts
 guid: 'https://rafaelnaufal.com/?p=753'
 ---

--- a/_drafts/about-junit-5-parameterized-tests733-autosave-v1-About-JUnit-5-parameterized-tests.md
+++ b/_drafts/about-junit-5-parameterized-tests733-autosave-v1-About-JUnit-5-parameterized-tests.md
@@ -1,7 +1,6 @@
 ---
 id: 738
 title: 'About JUnit 5 parameterized tests'
-date: '2022-12-18T19:44:25-03:00'
 layout: revision
 guid: 'https://rafaelnaufal.com/?p=738'
 ---

--- a/_drafts/about-junit-5-parameterized-tests733-revision-v1-About-JUnit-5-and-parameterized-tests.md
+++ b/_drafts/about-junit-5-parameterized-tests733-revision-v1-About-JUnit-5-and-parameterized-tests.md
@@ -1,7 +1,6 @@
 ---
 id: 736
 title: 'About JUnit 5 and parameterized tests'
-date: '2022-12-18T19:40:48-03:00'
 layout: revision
 guid: 'https://rafaelnaufal.com/?p=736'
 ---

--- a/_drafts/about-junit-5-parameterized-tests733-revision-v1-About-JUnit-5-parameterized-tests.md
+++ b/_drafts/about-junit-5-parameterized-tests733-revision-v1-About-JUnit-5-parameterized-tests.md
@@ -1,7 +1,6 @@
 ---
 id: 737
 title: 'About JUnit 5 parameterized tests'
-date: '2022-12-18T19:43:06-03:00'
 layout: revision
 guid: 'https://rafaelnaufal.com/?p=737'
 ---

--- a/_drafts/about-patterns-for-handling-errors-in-kafka-applications754-revision-v1-About-patterns-for-handling-errors-in-Kafka-applications.md
+++ b/_drafts/about-patterns-for-handling-errors-in-kafka-applications754-revision-v1-About-patterns-for-handling-errors-in-Kafka-applications.md
@@ -1,7 +1,6 @@
 ---
 id: 757
 title: 'About patterns for handling errors in Kafka applications'
-date: '2024-11-23T19:57:07-03:00'
 layout: revision
 guid: 'https://rafaelnaufal.com/?p=757'
 ---

--- a/_drafts/about-using-test-doubles-in-tests740-revision-v1-About-using-Test-Doubles-in-tests.md
+++ b/_drafts/about-using-test-doubles-in-tests740-revision-v1-About-using-Test-Doubles-in-tests.md
@@ -1,7 +1,6 @@
 ---
 id: 749
 title: 'About using Test Doubles in tests'
-date: '2024-03-08T17:14:07-03:00'
 layout: revision
 guid: 'https://rafaelnaufal.com/?p=749'
 ---

--- a/_drafts/about-using-test-doubles-in-tests740-revision-v1-Using-Test-Doubles-in-tests.md
+++ b/_drafts/about-using-test-doubles-in-tests740-revision-v1-Using-Test-Doubles-in-tests.md
@@ -1,7 +1,6 @@
 ---
 id: 743
 title: 'Using Test Doubles in tests'
-date: '2024-03-08T15:11:13-03:00'
 layout: revision
 guid: 'https://rafaelnaufal.com/?p=743'
 ---

--- a/_drafts/writing-your-own-custom-java-stream-collector723-autosave-v1-Writing-your-own-custom-Java-stream-collector.md
+++ b/_drafts/writing-your-own-custom-java-stream-collector723-autosave-v1-Writing-your-own-custom-Java-stream-collector.md
@@ -1,8 +1,6 @@
 ---
 id: 732
 title: 'Writing your own custom Java stream collector'
-date: '2022-12-17T12:29:02-03:00'
-
 layout: revision
 guid: 'https://rafaelnaufal.com/?p=732'
 ---

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,7 +1,6 @@
 ---
 id: 74
 title: 'About me'
-date: '2009-06-02T13:49:50-03:00'
 guid: 'http://rafaelnaufal.com/blog/?page_id=74'
 dsq_thread_id:
     - '102963585'

--- a/_posts/2006-05-25-introducing-myself.md
+++ b/_posts/2006-05-25-introducing-myself.md
@@ -1,7 +1,6 @@
 ---
 id: 6
 title: 'Introducing myself'
-date: '2006-05-25T22:34:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/05/25/introducing-myself/'
 lj_itemid:
     - '1'

--- a/_posts/2006-05-25-sun-is-gonna-open-source-java.md
+++ b/_posts/2006-05-25-sun-is-gonna-open-source-java.md
@@ -1,7 +1,6 @@
 ---
 id: 7
 title: 'Sun is gonna open source Java?'
-date: '2006-05-25T22:53:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/05/25/sun-is-gonna-open-source-java/'
 lj_itemid:
     - '2'

--- a/_posts/2006-05-30-early-abort-idiom.md
+++ b/_posts/2006-05-30-early-abort-idiom.md
@@ -1,7 +1,6 @@
 ---
 id: 8
 title: 'Early abort idiom'
-date: '2006-05-30T16:07:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/05/30/early-abort-idiom/'
 lj_itemid:
     - '3'

--- a/_posts/2006-06-06-blu-ray-the-next-generation-optical-disc-format.md
+++ b/_posts/2006-06-06-blu-ray-the-next-generation-optical-disc-format.md
@@ -1,7 +1,6 @@
 ---
 id: 9
 title: 'Blu-ray &#8211; The next-generation optical disc format'
-date: '2006-06-06T23:23:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/06/06/blu-ray-the-next-generation-optical-disc-format/'
 lj_itemid:
     - '4'

--- a/_posts/2006-06-07-association-or-aggregation.md
+++ b/_posts/2006-06-07-association-or-aggregation.md
@@ -1,7 +1,6 @@
 ---
 id: 10
 title: 'Association or Aggregation?'
-date: '2006-06-07T10:27:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/06/07/association-or-aggregation/'
 lj_itemid:
     - '5'

--- a/_posts/2006-06-08-explorer-destroyer.md
+++ b/_posts/2006-06-08-explorer-destroyer.md
@@ -1,7 +1,6 @@
 ---
 id: 11
 title: 'Explorer Destroyer'
-date: '2006-06-08T22:42:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/06/08/explorer-destroyer/'
 lj_itemid:
     - '6'

--- a/_posts/2006-06-08-microsoft-on-net-nasties.md
+++ b/_posts/2006-06-08-microsoft-on-net-nasties.md
@@ -1,7 +1,6 @@
 ---
 id: 12
 title: 'Microsoft on net nasties'
-date: '2006-06-08T23:06:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/06/08/microsoft-on-net-nasties/'
 lj_itemid:
     - '7'

--- a/_posts/2006-06-13-ant-could-not-find-the-main-class-program-will-exit.md
+++ b/_posts/2006-06-13-ant-could-not-find-the-main-class-program-will-exit.md
@@ -1,7 +1,6 @@
 ---
 id: 13
 title: 'Ant “Could not find the main class. Program will exit”'
-date: '2006-06-13T14:45:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/06/13/ant-%e2%80%9ccould-not-find-the-main-class-program-will-exit%e2%80%9d/'
 lj_itemid:
     - '8'

--- a/_posts/2006-06-13-aurora-7500-desktop.md
+++ b/_posts/2006-06-13-aurora-7500-desktop.md
@@ -1,7 +1,6 @@
 ---
 id: 14
 title: 'Aurora 7500 Desktop'
-date: '2006-06-13T14:54:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/06/13/aurora-7500-desktop/'
 lj_itemid:
     - '9'

--- a/_posts/2006-06-17-spyware-killer.md
+++ b/_posts/2006-06-17-spyware-killer.md
@@ -1,7 +1,6 @@
 ---
 id: 15
 title: 'Spyware killer'
-date: '2006-06-17T13:10:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/06/17/spyware-killer/'
 lj_itemid:
     - '10'

--- a/_posts/2006-06-20-google-increasing-its-computing-power.md
+++ b/_posts/2006-06-20-google-increasing-its-computing-power.md
@@ -1,7 +1,6 @@
 ---
 id: 16
 title: 'Google increasing its computing power'
-date: '2006-06-20T12:50:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/06/20/google-increasing-its-computing-power/'
 lj_itemid:
     - '11'

--- a/_posts/2006-06-26-jatalla-new-web-search-engines-experience.md
+++ b/_posts/2006-06-26-jatalla-new-web-search-engines-experience.md
@@ -1,7 +1,6 @@
 ---
 id: 17
 title: 'Jatalla &#8211; New web search engine&#8217;s experience'
-date: '2006-06-26T20:42:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/06/26/jatalla-new-web-search-engines-experience/'
 lj_itemid:
     - '12'

--- a/_posts/2006-07-03-eclipse-callisto-is-finally-released.md
+++ b/_posts/2006-07-03-eclipse-callisto-is-finally-released.md
@@ -1,7 +1,6 @@
 ---
 id: 18
 title: 'Eclipse Callisto is finally released!'
-date: '2006-07-03T21:47:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/07/03/eclipse-callisto-is-finally-released/'
 lj_itemid:
     - '13'

--- a/_posts/2006-07-06-guidelines-about-threads.md
+++ b/_posts/2006-07-06-guidelines-about-threads.md
@@ -1,7 +1,6 @@
 ---
 id: 19
 title: 'Guidelines about threads'
-date: '2006-07-06T14:29:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/07/06/guidelines-about-threads/'
 lj_itemid:
     - '14'

--- a/_posts/2006-07-11-software-testing-purposes.md
+++ b/_posts/2006-07-11-software-testing-purposes.md
@@ -1,7 +1,6 @@
 ---
 id: 20
 title: 'Software testing purposes'
-date: '2006-07-11T08:27:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/07/11/software-testing-purposes/'
 lj_itemid:
     - '15'

--- a/_posts/2006-07-13-about-version-control.md
+++ b/_posts/2006-07-13-about-version-control.md
@@ -1,7 +1,6 @@
 ---
 id: 21
 title: 'About version control'
-date: '2006-07-13T23:38:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/07/13/about-version-control/'
 lj_itemid:
     - '16'

--- a/_posts/2006-07-18-thread-groups.md
+++ b/_posts/2006-07-18-thread-groups.md
@@ -1,7 +1,6 @@
 ---
 id: 22
 title: 'Thread Groups'
-date: '2006-07-18T20:15:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/07/18/thread-groups/'
 lj_itemid:
     - '17'

--- a/_posts/2006-07-27-good-api-design-rule.md
+++ b/_posts/2006-07-27-good-api-design-rule.md
@@ -1,7 +1,6 @@
 ---
 id: 23
 title: 'Good API design rule'
-date: '2006-07-27T23:24:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/07/27/good-api-design-rule/'
 lj_itemid:
     - '18'

--- a/_posts/2006-08-06-grasp-patterns.md
+++ b/_posts/2006-08-06-grasp-patterns.md
@@ -1,7 +1,6 @@
 ---
 id: 246
 title: 'GRASP patterns'
-date: '2006-08-06T14:05:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/08/06/grasp-patterns/'
 lj_itemid:
     - '19'

--- a/_posts/2006-08-10-interfaces-and-abstract-classes.md
+++ b/_posts/2006-08-10-interfaces-and-abstract-classes.md
@@ -1,7 +1,6 @@
 ---
 id: 247
 title: 'Interfaces and Abstract classes'
-date: '2006-08-10T23:47:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/08/10/interfaces-and-abstract-classes/'
 lj_itemid:
     - '20'

--- a/_posts/2006-08-15-single-responsability-principle.md
+++ b/_posts/2006-08-15-single-responsability-principle.md
@@ -1,7 +1,6 @@
 ---
 id: 24
 title: 'Single Responsability Principle'
-date: '2006-08-15T23:06:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/08/15/single-responsability-principle/'
 lj_itemid:
     - '21'

--- a/_posts/2006-08-23-open-sourcing-java-good-or-bad.md
+++ b/_posts/2006-08-23-open-sourcing-java-good-or-bad.md
@@ -1,7 +1,6 @@
 ---
 id: 25
 title: 'Open sourcing Java: good or bad?'
-date: '2006-08-23T22:41:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/08/23/open-sourcing-java-good-or-bad/'
 lj_itemid:
     - '22'

--- a/_posts/2006-09-11-applying-the-law-of-demeter.md
+++ b/_posts/2006-09-11-applying-the-law-of-demeter.md
@@ -1,7 +1,6 @@
 ---
 id: 26
 title: 'Applying the Law of Demeter'
-date: '2006-09-11T00:01:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/09/11/applying-the-law-of-demeter/'
 lj_itemid:
     - '32'

--- a/_posts/2006-09-18-srp-example-bowling-game.md
+++ b/_posts/2006-09-18-srp-example-bowling-game.md
@@ -1,7 +1,6 @@
 ---
 id: 27
 title: 'SRP Example &#8211; Bowling Game'
-date: '2006-09-18T19:52:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/09/18/srp-example-bowling-game/'
 lj_itemid:
     - '33'

--- a/_posts/2006-10-04-spring-2-0-released.md
+++ b/_posts/2006-10-04-spring-2-0-released.md
@@ -1,7 +1,6 @@
 ---
 id: 28
 title: 'Spring 2.0 released'
-date: '2006-10-04T20:32:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/10/04/spring-2-0-released/'
 lj_itemid:
     - '34'

--- a/_posts/2006-10-09-about-refactoring.md
+++ b/_posts/2006-10-09-about-refactoring.md
@@ -1,7 +1,6 @@
 ---
 id: 29
 title: 'About Refactoring'
-date: '2006-10-09T00:11:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/10/09/about-refactoring/'
 lj_itemid:
     - '35'

--- a/_posts/2006-10-25-fasttrack-free-tracker-plugin-for-eclipse.md
+++ b/_posts/2006-10-25-fasttrack-free-tracker-plugin-for-eclipse.md
@@ -1,7 +1,6 @@
 ---
 id: 30
 title: 'FastTrack – Free Tracker plugin for Eclipse'
-date: '2006-10-25T23:58:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/10/25/fasttrack-%e2%80%93-free-tracker-plugin-for-eclipse/'
 lj_itemid:
     - '36'

--- a/_posts/2006-11-04-list-or-listobject.md
+++ b/_posts/2006-11-04-list-or-listobject.md
@@ -1,7 +1,6 @@
 ---
 id: 31
 title: 'List<?> or List<Object> ?'
-date: '2006-11-04T00:03:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2006/11/04/list-or-listobject/'
 lj_itemid:
     - '37'

--- a/_posts/2006-11-12-open-sourcing-java-with-gpl-license.md
+++ b/_posts/2006-11-12-open-sourcing-java-with-gpl-license.md
@@ -1,7 +1,6 @@
 ---
 id: 32
 title: 'Open sourcing Java with GPL license?'
-date: '2006-11-12T15:13:00-02:00'
 guid: 'http://rnaufal.wordpress.com/2006/11/12/open-sourcing-java-with-gpl-license/'
 lj_itemid:
     - '38'

--- a/_posts/2006-11-15-indicating-the-absence-of-an-object.md
+++ b/_posts/2006-11-15-indicating-the-absence-of-an-object.md
@@ -1,7 +1,6 @@
 ---
 id: 33
 title: 'Indicating the absence of an object'
-date: '2006-11-15T23:41:00-02:00'
 guid: 'http://rnaufal.wordpress.com/2006/11/15/indicating-the-absence-of-an-object/'
 lj_itemid:
     - '39'

--- a/_posts/2006-12-10-checked-or-unchecked.md
+++ b/_posts/2006-12-10-checked-or-unchecked.md
@@ -1,7 +1,6 @@
 ---
 id: 34
 title: 'Checked or Unchecked?'
-date: '2006-12-10T21:42:00-02:00'
 guid: 'http://rnaufal.wordpress.com/2006/12/10/checked-or-unchecked/'
 lj_itemid:
     - '40'

--- a/_posts/2007-01-03-setting-up-a-local-svn-on-linux-and-windows.md
+++ b/_posts/2007-01-03-setting-up-a-local-svn-on-linux-and-windows.md
@@ -1,7 +1,6 @@
 ---
 id: 35
 title: 'Setting up a local SVN on Linux and Windows'
-date: '2007-01-03T23:19:00-02:00'
 guid: 'http://rnaufal.wordpress.com/2007/01/03/setting-up-a-local-svn-on-linux-and-windows/'
 lj_itemid:
     - '41'

--- a/_posts/2007-02-22-dont-be-passionate-with-your-language-of-choice.md
+++ b/_posts/2007-02-22-dont-be-passionate-with-your-language-of-choice.md
@@ -1,7 +1,6 @@
 ---
 id: 36
 title: 'Don&#8217;t be passionate with your language of choice &#8230;'
-date: '2007-02-22T23:58:00-02:00'
 guid: 'http://rnaufal.wordpress.com/2007/02/22/dont-be-passionate-with-your-language-of-choice/'
 lj_itemid:
     - '42'

--- a/_posts/2007-03-31-interview-with-grady-booch.md
+++ b/_posts/2007-03-31-interview-with-grady-booch.md
@@ -1,7 +1,6 @@
 ---
 id: 37
 title: 'Interview with Grady Booch'
-date: '2007-03-31T20:15:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2007/03/31/interview-with-grady-booch/'
 lj_itemid:
     - '43'

--- a/_posts/2007-04-15-integrating-struts-and-spring.md
+++ b/_posts/2007-04-15-integrating-struts-and-spring.md
@@ -1,7 +1,6 @@
 ---
 id: 38
 title: 'Integrating Struts and Spring'
-date: '2007-04-15T19:53:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2007/04/15/integrating-struts-and-spring/'
 lj_itemid:
     - '44'

--- a/_posts/2007-04-15-method-refactoring.md
+++ b/_posts/2007-04-15-method-refactoring.md
@@ -1,7 +1,6 @@
 ---
 id: 39
 title: 'Method Refactoring'
-date: '2007-04-15T22:52:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2007/04/15/method-refactoring/'
 lj_itemid:
     - '45'

--- a/_posts/2007-05-17-inspect-your-java-codebase-with-semmlecode.md
+++ b/_posts/2007-05-17-inspect-your-java-codebase-with-semmlecode.md
@@ -1,7 +1,6 @@
 ---
 id: 40
 title: 'Inspect your Java codebase with SemmleCode'
-date: '2007-05-17T20:30:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2007/05/17/inspect-your-java-codebase-with-semmlecode/'
 lj_itemid:
     - '46'

--- a/_posts/2007-05-22-firefox-tips-and-tricks.md
+++ b/_posts/2007-05-22-firefox-tips-and-tricks.md
@@ -1,7 +1,6 @@
 ---
 id: 41
 title: 'Firefox tips and tricks'
-date: '2007-05-22T23:45:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2007/05/22/firefox-tips-and-tricks/'
 lj_itemid:
     - '47'

--- a/_posts/2007-06-03-google-guice-dependence-inversion-in-the-java-way.md
+++ b/_posts/2007-06-03-google-guice-dependence-inversion-in-the-java-way.md
@@ -1,7 +1,6 @@
 ---
 id: 42
 title: 'Google Guice, dependence Inversion in the Java way'
-date: '2007-06-03T19:02:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2007/06/03/google-guice-dependence-inversion-in-the-java-way/'
 lj_itemid:
     - '48'

--- a/_posts/2007-06-10-web-2-0-neglecting-good-design.md
+++ b/_posts/2007-06-10-web-2-0-neglecting-good-design.md
@@ -1,7 +1,6 @@
 ---
 id: 43
 title: 'Web 2.0 &#8216;neglecting good design&#8217;'
-date: '2007-06-10T22:48:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2007/06/10/web-2-0-neglecting-good-design/'
 lj_itemid:
     - '49'

--- a/_posts/2007-06-13-do-you-need-closures-in-java.md
+++ b/_posts/2007-06-13-do-you-need-closures-in-java.md
@@ -1,7 +1,6 @@
 ---
 id: 44
 title: 'Do you need closures in Java?'
-date: '2007-06-13T16:11:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2007/06/13/do-you-need-closures-in-java/'
 lj_itemid:
     - '50'

--- a/_posts/2007-06-24-thinking-iterative-but-doing-waterfall-development.md
+++ b/_posts/2007-06-24-thinking-iterative-but-doing-waterfall-development.md
@@ -1,7 +1,6 @@
 ---
 id: 45
 title: 'Thinking Iterative, but doing Waterfall development'
-date: '2007-06-24T23:19:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2007/06/24/thinking-iterative-but-doing-waterfall-development/'
 lj_itemid:
     - '51'

--- a/_posts/2007-08-16-about-use-case-reuse.md
+++ b/_posts/2007-08-16-about-use-case-reuse.md
@@ -1,7 +1,6 @@
 ---
 id: 46
 title: 'About use case reuse'
-date: '2007-08-16T23:22:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2007/08/16/about-use-case-reuse/'
 lj_itemid:
     - '52'

--- a/_posts/2007-08-26-see-through-mobile-devices.md
+++ b/_posts/2007-08-26-see-through-mobile-devices.md
@@ -1,7 +1,6 @@
 ---
 id: 47
 title: 'See-Through Mobile Devices'
-date: '2007-08-26T23:23:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2007/08/26/see-through-mobile-devices/'
 lj_itemid:
     - '53'

--- a/_posts/2007-09-04-why-not-design-patterns.md
+++ b/_posts/2007-09-04-why-not-design-patterns.md
@@ -1,7 +1,6 @@
 ---
 id: 48
 title: 'Why not design patterns?'
-date: '2007-09-04T23:52:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2007/09/04/why-not-design-patterns/'
 lj_itemid:
     - '54'

--- a/_posts/2007-09-16-changing-firefox-profile-location-on-win.md
+++ b/_posts/2007-09-16-changing-firefox-profile-location-on-win.md
@@ -1,7 +1,6 @@
 ---
 id: 49
 title: 'Changing Firefox profile location on Win'
-date: '2007-09-16T23:04:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2007/09/16/changing-firefox-profile-location-on-win/'
 lj_itemid:
     - '55'

--- a/_posts/2007-10-08-reducing-the-distance-between-programming-and-project-management.md
+++ b/_posts/2007-10-08-reducing-the-distance-between-programming-and-project-management.md
@@ -1,7 +1,6 @@
 ---
 id: 50
 title: 'Reducing the distance between programming and project management'
-date: '2007-10-08T16:24:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2007/10/08/reducing-the-distance-between-programming-and-project-management/'
 lj_itemid:
     - '56'

--- a/_posts/2007-10-30-how-hard-could-it-be-five-easy-ways-to-fail.md
+++ b/_posts/2007-10-30-how-hard-could-it-be-five-easy-ways-to-fail.md
@@ -1,7 +1,6 @@
 ---
 id: 51
 title: 'How Hard Could It Be? Five Easy Ways to Fail'
-date: '2007-10-30T14:55:00-02:00'
 guid: 'http://rnaufal.wordpress.com/2007/10/30/how-hard-could-it-be-five-easy-ways-to-fail/'
 lj_itemid:
     - '57'

--- a/_posts/2007-11-06-google-announces-android.md
+++ b/_posts/2007-11-06-google-announces-android.md
@@ -1,7 +1,6 @@
 ---
 id: 53
 title: 'Google announces Android'
-date: '2007-11-06T22:18:00-02:00'
 guid: 'http://rnaufal.wordpress.com/2007/11/06/google-announces-android/'
 lj_itemid:
     - '59'

--- a/_posts/2007-11-06-the-war-between-apple-and-developers.md
+++ b/_posts/2007-11-06-the-war-between-apple-and-developers.md
@@ -1,7 +1,6 @@
 ---
 id: 52
 title: 'The war between Apple and developers'
-date: '2007-11-06T20:34:00-02:00'
 guid: 'http://rnaufal.wordpress.com/2007/11/06/the-war-between-apple-and-developers/'
 lj_itemid:
     - '58'

--- a/_posts/2007-11-19-swing-tips-and-tricks.md
+++ b/_posts/2007-11-19-swing-tips-and-tricks.md
@@ -1,7 +1,6 @@
 ---
 id: 54
 title: 'Swing tips and tricks'
-date: '2007-11-19T23:16:00-02:00'
 guid: 'http://rnaufal.wordpress.com/2007/11/19/swing-tips-and-tricks/'
 lj_itemid:
     - '62'

--- a/_posts/2007-11-29-testsuite-merlin-javadoc.md
+++ b/_posts/2007-11-29-testsuite-merlin-javadoc.md
@@ -1,7 +1,6 @@
 ---
 id: 55
 title: 'TestSuite Merlin javadoc'
-date: '2007-11-29T21:26:00-02:00'
 guid: 'http://rnaufal.wordpress.com/2007/11/29/testsuite-merlin-javadoc/'
 lj_itemid:
     - '63'

--- a/_posts/2007-12-11-strongly-java-typed-safe-delegates.md
+++ b/_posts/2007-12-11-strongly-java-typed-safe-delegates.md
@@ -1,7 +1,6 @@
 ---
 id: 56
 title: 'Strongly Java typed safe delegates'
-date: '2007-12-11T22:57:00-02:00'
 guid: 'http://rnaufal.wordpress.com/2007/12/11/strongly-java-typed-safe-delegates/'
 lj_itemid:
     - '64'

--- a/_posts/2008-01-02-jfilecontentmanager-has-been-released.md
+++ b/_posts/2008-01-02-jfilecontentmanager-has-been-released.md
@@ -1,7 +1,6 @@
 ---
 id: 57
 title: 'JFileContentManager has been released!'
-date: '2008-01-02T22:32:00-02:00'
 guid: 'http://rnaufal.wordpress.com/2008/01/02/jfilecontentmanager-has-been-released/'
 lj_itemid:
     - '65'

--- a/_posts/2008-01-11-is-java-on-a-evolutionary-dead-end-way.md
+++ b/_posts/2008-01-11-is-java-on-a-evolutionary-dead-end-way.md
@@ -1,7 +1,6 @@
 ---
 id: 58
 title: 'Is Java on a evolutionary dead end way?'
-date: '2008-01-11T00:31:00-02:00'
 guid: 'http://rnaufal.wordpress.com/2008/01/11/is-java-on-a-evolutionary-dead-end-way/'
 lj_itemid:
     - '66'

--- a/_posts/2008-01-13-effective-java-programming-with-joshua-bloch.md
+++ b/_posts/2008-01-13-effective-java-programming-with-joshua-bloch.md
@@ -1,7 +1,6 @@
 ---
 id: 59
 title: 'Effective Java Programming with Joshua Bloch'
-date: '2008-01-13T18:07:00-02:00'
 guid: 'http://rnaufal.wordpress.com/2008/01/13/effective-java-programming-with-joshua-bloch/'
 lj_itemid:
     - '67'

--- a/_posts/2008-01-26-annoucing-jfilecontentmanager-1-2.md
+++ b/_posts/2008-01-26-annoucing-jfilecontentmanager-1-2.md
@@ -1,7 +1,6 @@
 ---
 id: 60
 title: 'Annoucing JFileContentManager 1.2!'
-date: '2008-01-26T23:30:00-02:00'
 guid: 'http://rnaufal.wordpress.com/2008/01/26/annoucing-jfilecontentmanager-1-2/'
 lj_itemid:
     - '68'

--- a/_posts/2008-02-11-generating-lgpl-notices-with-python-support.md
+++ b/_posts/2008-02-11-generating-lgpl-notices-with-python-support.md
@@ -1,7 +1,6 @@
 ---
 id: 61
 title: 'Generating LGPL notices with Python support'
-date: '2008-02-11T00:19:00-02:00'
 guid: 'http://rnaufal.wordpress.com/2008/02/11/generating-lgpl-notices-with-python-support/'
 lj_itemid:
     - '69'

--- a/_posts/2008-03-31-domaindrivendesign-domain-services-or-method-on-an-entity.md
+++ b/_posts/2008-03-31-domaindrivendesign-domain-services-or-method-on-an-entity.md
@@ -1,7 +1,6 @@
 ---
 id: 62
 title: 'DomainDrivenDesign: Domain Services or Method on an Entity?'
-date: '2008-03-31T00:50:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2008/03/31/domaindrivendesign-domain-services-or-method-on-an-entity/'
 lj_itemid:
     - '70'

--- a/_posts/2008-05-01-about-css2-selectors.md
+++ b/_posts/2008-05-01-about-css2-selectors.md
@@ -1,7 +1,6 @@
 ---
 id: 63
 title: 'About CSS2 Selectors'
-date: '2008-05-01T00:29:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2008/05/01/about-css2-selectors/'
 lj_itemid:
     - '71'

--- a/_posts/2008-06-12-the-fan-programming-language.md
+++ b/_posts/2008-06-12-the-fan-programming-language.md
@@ -1,7 +1,6 @@
 ---
 id: 64
 title: 'The Fan programming language'
-date: '2008-06-12T17:35:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2008/06/12/the-fan-programming-language/'
 lj_itemid:
     - '72'

--- a/_posts/2008-08-25-my-first-impressions-about-latex.md
+++ b/_posts/2008-08-25-my-first-impressions-about-latex.md
@@ -1,7 +1,6 @@
 ---
 id: 65
 title: 'My first impressions about LaTex'
-date: '2008-08-25T00:00:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2008/08/25/my-first-impressions-about-latex/'
 lj_itemid:
     - '74'

--- a/_posts/2008-10-28-erich-gamma-discusses-jazz-eclipse-junit-and-design-patterns.md
+++ b/_posts/2008-10-28-erich-gamma-discusses-jazz-eclipse-junit-and-design-patterns.md
@@ -1,7 +1,6 @@
 ---
 id: 66
 title: 'Erich Gamma Discusses Jazz, Eclipse, JUnit and Design Patterns'
-date: '2008-10-28T23:33:00-02:00'
 guid: 'http://rnaufal.wordpress.com/2008/10/28/erich-gamma-discusses-jazz-eclipse-junit-and-design-patterns/'
 lj_itemid:
     - '75'

--- a/_posts/2009-01-10-joshua-block-on-how-to-design-a-good-api-why-it-matters.md
+++ b/_posts/2009-01-10-joshua-block-on-how-to-design-a-good-api-why-it-matters.md
@@ -1,7 +1,6 @@
 ---
 id: 67
 title: 'Joshua Block on How to Design a Good API &#038; Why it Matters'
-date: '2009-01-10T18:36:00-02:00'
 guid: 'http://rnaufal.wordpress.com/2009/01/10/joshua-block-on-how-to-design-a-good-api-why-it-matters/'
 lj_itemid:
     - '76'

--- a/_posts/2009-02-02-installing-vista-and-restoring-grub-from-a-live-kubuntu-cd.md
+++ b/_posts/2009-02-02-installing-vista-and-restoring-grub-from-a-live-kubuntu-cd.md
@@ -1,7 +1,6 @@
 ---
 id: 68
 title: 'Installing Vista..and restoring Grub from a live Kubuntu cd..'
-date: '2009-02-02T23:06:00-02:00'
 guid: 'http://rnaufal.wordpress.com/2009/02/02/installing-vista-and-restoring-grub-from-a-live-kubuntu-cd/'
 lj_itemid:
     - '77'

--- a/_posts/2009-03-22-bean-validation-emmanuel-bernard-on-jsr-303.md
+++ b/_posts/2009-03-22-bean-validation-emmanuel-bernard-on-jsr-303.md
@@ -1,7 +1,6 @@
 ---
 id: 69
 title: 'Bean Validation – Emmanuel Bernard on JSR 303'
-date: '2009-03-22T14:57:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2009/03/22/bean-validation-%e2%80%93-emmanuel-bernard-on-jsr-303/'
 lj_itemid:
     - '78'

--- a/_posts/2009-04-17-twitter-ecosystem-tools.md
+++ b/_posts/2009-04-17-twitter-ecosystem-tools.md
@@ -1,7 +1,6 @@
 ---
 id: 70
 title: 'Twitter Ecosystem Tools'
-date: '2009-04-17T09:44:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2009/04/17/twitter-ecosystem-tools/'
 lj_itemid:
     - '79'

--- a/_posts/2009-04-27-twitter-on-scala-interview.md
+++ b/_posts/2009-04-27-twitter-on-scala-interview.md
@@ -1,7 +1,6 @@
 ---
 id: 71
 title: 'Twitter on Scala Interview'
-date: '2009-04-27T14:05:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2009/04/27/twitter-on-scala-interview/'
 lj_itemid:
     - '80'

--- a/_posts/2009-05-21-salute-ruby.md
+++ b/_posts/2009-05-21-salute-ruby.md
@@ -1,7 +1,6 @@
 ---
 id: 72
 title: '&#8220;Salute #{@Ruby}!&#8221;'
-date: '2009-05-21T22:15:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2009/05/21/salute-ruby/'
 lj_itemid:
     - '81'

--- a/_posts/2009-05-23-using-scala-to-update-livejournal-tags-part-i.md
+++ b/_posts/2009-05-23-using-scala-to-update-livejournal-tags-part-i.md
@@ -1,7 +1,6 @@
 ---
 id: 73
 title: 'Using Scala to update LiveJournal tags &#8211; Part I'
-date: '2009-05-23T13:45:00-03:00'
 guid: 'http://rnaufal.wordpress.com/2009/05/23/using-scala-to-update-livejournal-tags-part-i/'
 lj_itemid:
     - '82'

--- a/_posts/2009-08-26-constructors-in-scala.md
+++ b/_posts/2009-08-26-constructors-in-scala.md
@@ -1,7 +1,6 @@
 ---
 id: 76
 title: 'Constructors in Scala'
-date: '2009-08-26T22:15:40-03:00'
 guid: 'http://rnaufal.wordpress.com/?p=76'
 dsq_thread_id:
     - '102750202'

--- a/_posts/2009-09-22-a-brief-history-of-java-and-jdbc.md
+++ b/_posts/2009-09-22-a-brief-history-of-java-and-jdbc.md
@@ -1,7 +1,6 @@
 ---
 id: 82
 title: 'A Brief History of Java and JDBC'
-date: '2009-09-22T22:23:44-03:00'
 guid: 'http://rafaelnaufal.com/blog/?p=82'
 dsq_thread_id:
     - '102798045'

--- a/_posts/2009-09-22-jdk7-tackles-java-verbosity.md
+++ b/_posts/2009-09-22-jdk7-tackles-java-verbosity.md
@@ -1,7 +1,6 @@
 ---
 id: 86
 title: 'JDK7 Tackles Java Verbosity'
-date: '2009-09-22T23:45:00-03:00'
 guid: 'http://rafaelnaufal.com/blog/?p=86'
 dsq_thread_id:
     - '102911457'

--- a/_posts/2009-10-27-effect-propagation-to-code.md
+++ b/_posts/2009-10-27-effect-propagation-to-code.md
@@ -1,7 +1,6 @@
 ---
 id: 126
 title: 'Effect propagation to code'
-date: '2009-10-27T23:20:26-02:00'
 guid: 'http://rafaelnaufal.com/blog/?p=126'
 dsq_thread_id:
     - '104138827'

--- a/_posts/2009-10-27-jfilecontentmanager-included-in-the-softpedia-mac-os-software-database.md
+++ b/_posts/2009-10-27-jfilecontentmanager-included-in-the-softpedia-mac-os-software-database.md
@@ -1,7 +1,6 @@
 ---
 id: 116
 title: 'JFileContentManager included in the Softpedia Mac OS software database'
-date: '2009-10-27T22:46:26-02:00'
 guid: 'http://rafaelnaufal.com/blog/?p=116'
 dsq_thread_id:
     - '104200459'

--- a/_posts/2009-11-11-product-owner-vs-product-manager.md
+++ b/_posts/2009-11-11-product-owner-vs-product-manager.md
@@ -1,7 +1,6 @@
 ---
 id: 136
 title: 'Product Owner vs Product Manager'
-date: '2009-11-11T08:18:21-02:00'
 guid: 'http://rafaelnaufal.com/blog/?p=136'
 dsq_thread_id:
     - '102751093'

--- a/_posts/2009-11-13-fixing-eclipse-buttons-for-ubuntu-9-10.md
+++ b/_posts/2009-11-13-fixing-eclipse-buttons-for-ubuntu-9-10.md
@@ -1,7 +1,6 @@
 ---
 id: 146
 title: 'Fixing Eclipse buttons for Ubuntu 9.10'
-date: '2009-11-13T15:43:17-02:00'
 guid: 'http://rafaelnaufal.com/blog/?p=146'
 dsq_thread_id:
     - '76181492'

--- a/_posts/2009-12-02-my-first-experiences-on-a-scrum-team.md
+++ b/_posts/2009-12-02-my-first-experiences-on-a-scrum-team.md
@@ -1,7 +1,6 @@
 ---
 id: 183
 title: 'My first experiences on a Scrum team'
-date: '2009-12-02T18:14:36-02:00'
 guid: 'http://rafaelnaufal.com/blog/?p=183'
 dsq_thread_id:
     - '76181487'

--- a/_posts/2009-12-03-mimecora-ds-added-as-lncs-at-springerlink.md
+++ b/_posts/2009-12-03-mimecora-ds-added-as-lncs-at-springerlink.md
@@ -1,7 +1,6 @@
 ---
 id: 197
 title: 'My paper MIMECORA-DS added as LNCS at SpringerLink'
-date: '2009-12-03T17:59:32-02:00'
 guid: 'http://rafaelnaufal.com/blog/?p=197'
 dsq_thread_id:
     - '76181469'

--- a/_posts/2010-01-14-the-power-of-pair-programming.md
+++ b/_posts/2010-01-14-the-power-of-pair-programming.md
@@ -1,7 +1,6 @@
 ---
 id: 206
 title: 'The power of pair programming'
-date: '2010-01-14T23:08:03-02:00'
 guid: 'http://rafaelnaufal.com/blog/?p=206'
 dsq_thread_id:
     - '76181486'

--- a/_posts/2010-03-15-using-hamcrest-and-junit.md
+++ b/_posts/2010-03-15-using-hamcrest-and-junit.md
@@ -1,7 +1,6 @@
 ---
 id: 218
 title: 'Using Hamcrest and JUnit'
-date: '2010-03-15T23:10:52-03:00'
 guid: 'http://rafaelnaufal.com/blog/?p=218'
 dsq_thread_id:
     - '76180944'

--- a/_posts/2010-05-09-eclipse-log4j-template.md
+++ b/_posts/2010-05-09-eclipse-log4j-template.md
@@ -1,7 +1,6 @@
 ---
 id: 253
 title: 'Eclipse Log4J template'
-date: '2010-05-09T16:56:23-03:00'
 guid: 'http://rafaelnaufal.com/blog/?p=253'
 dsq_thread_id:
     - '102697806'

--- a/_posts/2010-08-03-java-quiz-the-iterator-quiz.md
+++ b/_posts/2010-08-03-java-quiz-the-iterator-quiz.md
@@ -1,7 +1,6 @@
 ---
 id: 267
 title: 'Java-Quiz: The Iterator Quiz'
-date: '2010-08-03T18:28:26-03:00'
 guid: 'http://rafaelnaufal.com/blog/?p=267'
 dsq_thread_id:
     - '125658658'

--- a/_posts/2010-09-07-singleton-in-java-with-enum-types.md
+++ b/_posts/2010-09-07-singleton-in-java-with-enum-types.md
@@ -1,7 +1,6 @@
 ---
 id: 312
 title: 'Singleton in Java with Enum types'
-date: '2010-09-07T16:31:08-03:00'
 guid: 'http://rafaelnaufal.com/blog/?p=312'
 dsq_thread_id:
     - '138792904'

--- a/_posts/2010-09-23-configuration-classes-with-enums.md
+++ b/_posts/2010-09-23-configuration-classes-with-enums.md
@@ -1,7 +1,6 @@
 ---
 id: 324
 title: 'Configuration classes with Enums'
-date: '2010-09-23T19:18:37-03:00'
 guid: 'http://rafaelnaufal.com/blog/?p=324'
 dsq_thread_id:
     - '146123313'

--- a/_posts/2011-08-22-maven-eclipse-plugin.md
+++ b/_posts/2011-08-22-maven-eclipse-plugin.md
@@ -1,7 +1,6 @@
 ---
 id: 338
 title: 'Maven Eclipse plugin using project dependencies'
-date: '2011-08-22T23:09:43-03:00'
 guid: 'http://rafaelnaufal.com/blog/?p=338'
 dsq_thread_id:
     - '393877427'

--- a/_posts/2011-08-24-some-interesting-maven-tips.md
+++ b/_posts/2011-08-24-some-interesting-maven-tips.md
@@ -1,7 +1,6 @@
 ---
 id: 353
 title: 'Some interesting Maven tips'
-date: '2011-08-24T21:46:52-03:00'
 guid: 'http://rafaelnaufal.com/blog/?p=353'
 dsq_thread_id:
     - '395145110'

--- a/_posts/2011-09-02-when-to-use-testng-or-junit.md
+++ b/_posts/2011-09-02-when-to-use-testng-or-junit.md
@@ -1,7 +1,6 @@
 ---
 id: 361
 title: 'When to use TestNG or JUnit'
-date: '2011-09-02T18:50:10-03:00'
 guid: 'http://rafaelnaufal.com/blog/?p=361'
 dsq_thread_id:
     - '403341604'

--- a/_posts/2012-06-20-checkout-only-one-file-from-subversion.md
+++ b/_posts/2012-06-20-checkout-only-one-file-from-subversion.md
@@ -1,7 +1,6 @@
 ---
 id: 368
 title: 'Checkout only one file from Subversion'
-date: '2012-06-20T13:57:40-03:00'
 guid: 'http://rafaelnaufal.com/blog/?p=368'
 dsq_thread_id:
     - '749002135'

--- a/_posts/2012-06-20-undo-svn-add-operation.md
+++ b/_posts/2012-06-20-undo-svn-add-operation.md
@@ -1,7 +1,6 @@
 ---
 id: 375
 title: 'Undo svn add operation'
-date: '2012-06-20T14:09:02-03:00'
 guid: 'http://rafaelnaufal.com/blog/?p=375'
 dsq_thread_id:
     - '751435668'

--- a/_posts/2013-08-11-finding-the-second-highest-frequency.md
+++ b/_posts/2013-08-11-finding-the-second-highest-frequency.md
@@ -1,7 +1,6 @@
 ---
 id: 386
 title: 'Finding the second highest frequency'
-date: '2013-08-11T23:11:07-03:00'
 guid: 'http://rafaelnaufal.com/blog/?p=386'
 dsq_thread_id:
     - '1598302814'

--- a/_posts/2013-08-23-balancing-arrays-puzzle-in-ruby.md
+++ b/_posts/2013-08-23-balancing-arrays-puzzle-in-ruby.md
@@ -1,7 +1,6 @@
 ---
 id: 398
 title: 'Balancing arrays puzzle in Ruby'
-date: '2013-08-23T17:37:21-03:00'
 guid: 'http://rafaelnaufal.com/blog/?p=398'
 dsq_thread_id:
     - '1635008168'

--- a/_posts/2013-08-28-minimum-difference-puzzle-in-ruby.md
+++ b/_posts/2013-08-28-minimum-difference-puzzle-in-ruby.md
@@ -1,7 +1,6 @@
 ---
 id: 410
 title: 'Minimum difference puzzle in Ruby'
-date: '2013-08-28T18:02:34-03:00'
 guid: 'http://rafaelnaufal.com/blog/?p=410'
 dsq_thread_id:
     - '1661474600'

--- a/_posts/2013-09-03-k-palindromes-puzzle.md
+++ b/_posts/2013-09-03-k-palindromes-puzzle.md
@@ -1,7 +1,6 @@
 ---
 id: 415
 title: 'K Palindromes puzzle'
-date: '2013-09-03T12:18:43-03:00'
 guid: 'http://rafaelnaufal.com/blog/?p=415'
 dsq_thread_id:
     - '1701712815'

--- a/_posts/2015-04-23-javacodekata-lambdas.md
+++ b/_posts/2015-04-23-javacodekata-lambdas.md
@@ -1,7 +1,6 @@
 ---
 id: 424
 title: 'JavaCodeKata &#8211; Lambdas'
-date: '2015-04-23T18:13:31-03:00'
 guid: 'http://rafaelnaufal.com/blog/?p=424'
 dsq_thread_id:
     - '3707200815'

--- a/_posts/2016-07-16-converting-a-map-to-a-list-in-java-8-groovy-and-ruby.md
+++ b/_posts/2016-07-16-converting-a-map-to-a-list-in-java-8-groovy-and-ruby.md
@@ -1,7 +1,6 @@
 ---
 id: 459
 title: 'Converting a Map to a List in Java 8, Groovy and Ruby'
-date: '2016-07-16T16:12:26-03:00'
 guid: 'http://rafaelnaufal.com/blog/?p=459'
 dsq_thread_id:
     - '4993151356'

--- a/_posts/2016-07-16-integration-tests-in-a-gradle-build.md
+++ b/_posts/2016-07-16-integration-tests-in-a-gradle-build.md
@@ -1,7 +1,6 @@
 ---
 id: 501
 title: 'Integration tests in a Gradle build'
-date: '2016-07-16T16:25:29-03:00'
 guid: 'http://rafaelnaufal.com/blog/?p=501'
 dsq_thread_id:
     - '5125988638'

--- a/_posts/2017-01-08-importing-and-debugging-eclipse-projects-in-intellij-idea.md
+++ b/_posts/2017-01-08-importing-and-debugging-eclipse-projects-in-intellij-idea.md
@@ -1,7 +1,6 @@
 ---
 id: 515
 title: 'Importing and debugging Eclipse projects in IntelliJ IDEA'
-date: '2017-01-08T20:03:45-02:00'
 guid: 'http://rafaelnaufal.com/blog/?p=515'
 dsq_thread_id:
     - '5446739941'

--- a/_posts/2017-08-20-35-programming-habits-that-make-your-code-smell.md
+++ b/_posts/2017-08-20-35-programming-habits-that-make-your-code-smell.md
@@ -1,7 +1,6 @@
 ---
 id: 542
 title: '35 programming habits that make your code smell'
-date: '2017-08-20T13:04:39-03:00'
 guid: 'http://rafaelnaufal.com/blog/?p=542'
 dsq_thread_id:
     - '6095661721'

--- a/_posts/2017-10-14-about-the-kotlin-programming-language.md
+++ b/_posts/2017-10-14-about-the-kotlin-programming-language.md
@@ -1,7 +1,6 @@
 ---
 id: 590
 title: 'About the Kotlin programming language'
-date: '2017-10-14T19:03:47-03:00'
 guid: 'http://rafaelnaufal.com/blog/?p=590'
 dsq_thread_id:
     - '6215656980'

--- a/_posts/2017-10-15-java-8-converting-optional-collection-to-the-streams-api.md
+++ b/_posts/2017-10-15-java-8-converting-optional-collection-to-the-streams-api.md
@@ -1,7 +1,6 @@
 ---
 id: 554
 title: 'Java 8: Converting Optional Collection to the Streams API'
-date: '2017-10-15T19:42:09-02:00'
 guid: 'http://rafaelnaufal.com/blog/?p=554'
 dsq_thread_id:
     - '6217518496'

--- a/_posts/2018-02-19-3-things-every-java-developer-should-stop-doing.md
+++ b/_posts/2018-02-19-3-things-every-java-developer-should-stop-doing.md
@@ -1,7 +1,6 @@
 ---
 id: 647
 title: '3 Things Every Java Developer Should Stop Doing'
-date: '2018-02-19T21:31:03-03:00'
 guid: 'http://rafaelnaufal.com/blog/?p=647'
 categories:
     - code

--- a/_posts/2018-02-20-streams-in-jdk-8-the-good-the-bad-and-the-ugly.md
+++ b/_posts/2018-02-20-streams-in-jdk-8-the-good-the-bad-and-the-ugly.md
@@ -1,7 +1,6 @@
 ---
 id: 655
 title: 'Streams in JDK 8: The Good, the Bad, and the Ugly'
-date: '2018-02-20T21:30:28-03:00'
 guid: 'http://rafaelnaufal.com/blog/?p=655'
 categories:
     - collectors

--- a/_posts/2018-09-10-refactoring-large-conditional-method-using-method-references.md
+++ b/_posts/2018-09-10-refactoring-large-conditional-method-using-method-references.md
@@ -1,7 +1,6 @@
 ---
 id: 673
 title: 'Refactoring large conditional method using method references'
-date: '2018-09-10T17:51:03-03:00'
 guid: 'https://rafaelnaufal.com/blog/?p=673'
 categories:
     - code

--- a/_posts/2018-11-27-jcombiner-combinations-of-collections-for-java.md
+++ b/_posts/2018-11-27-jcombiner-combinations-of-collections-for-java.md
@@ -1,7 +1,6 @@
 ---
 id: 697
 title: 'Jcombiner: Combinations of collections for Java'
-date: '2018-11-27T22:49:10-02:00'
 guid: 'https://rafaelnaufal.com/blog/?p=697'
 medium_post:
     - 'O:11:"Medium_Post":11:{s:16:"author_image_url";s:74:"https://cdn-images-1.medium.com/fit/c/400/400/1*HWcHVsU9HX3OxkzLCFLyGQ.png";s:10:"author_url";s:27:"https://medium.com/@rnaufal";s:11:"byline_name";N;s:12:"byline_email";N;s:10:"cross_link";s:3:"yes";s:2:"id";s:12:"e6502c9cea57";s:21:"follower_notification";s:3:"yes";s:7:"license";s:19:"all-rights-reserved";s:14:"publication_id";s:2:"-1";s:6:"status";s:5:"draft";s:3:"url";s:40:"https://medium.com/@rnaufal/e6502c9cea57";}'

--- a/_posts/2020-03-29-writing-your-own-custom-java-stream-collector.md
+++ b/_posts/2020-03-29-writing-your-own-custom-java-stream-collector.md
@@ -1,7 +1,6 @@
 ---
 id: 723
 title: 'Writing your own custom Java stream collector'
-date: '2020-03-29T21:37:17-03:00'
 guid: 'https://rafaelnaufal.com/blog/?p=723'
 categories:
     - collections

--- a/_posts/2022-12-18-about-junit-5-parameterized-tests.md
+++ b/_posts/2022-12-18-about-junit-5-parameterized-tests.md
@@ -1,7 +1,6 @@
 ---
 id: 733
 title: 'About JUnit 5 parameterized tests'
-date: '2022-12-18T19:40:48-03:00'
 guid: 'https://rafaelnaufal.com/?p=733'
 categories:
     - java

--- a/_posts/2024-03-08-about-using-test-doubles-in-tests.md
+++ b/_posts/2024-03-08-about-using-test-doubles-in-tests.md
@@ -1,7 +1,6 @@
 ---
 id: 740
 title: 'About using Test Doubles in tests'
-date: '2024-03-08T15:52:10-03:00'
 guid: 'https://rafaelnaufal.com/?p=740'
 categories:
     - java

--- a/_posts/2024-11-23-about-patterns-for-handling-errors-in-kafka-applications.md
+++ b/_posts/2024-11-23-about-patterns-for-handling-errors-in-kafka-applications.md
@@ -1,7 +1,6 @@
 ---
 id: 754
 title: 'About patterns for handling errors in Kafka applications'
-date: '2024-11-23T19:52:52-03:00'
 guid: 'https://rafaelnaufal.com/?p=754'
 categories:
     - development


### PR DESCRIPTION
This pull request updates the `date` metadata field across multiple markdown files in the repository. The changes primarily involve correcting or modifying the `date` values in drafts, pages, and posts.

### Updates to drafts:

* [`_drafts/Auto-Draft.md`](diffhunk://#diff-91f048a1a7e77e744d9fe05a48acb842e82dab8338277838ca92cb3db35d3199L4): Adjusted the `date` field to reflect the correct timestamp for the draft.
* [`_drafts/about-junit-5-parameterized-tests733-autosave-v1-About-JUnit-5-parameterized-tests.md`](diffhunk://#diff-0d2c6f19c63c3c408de3f8d37fb54bc1063fdc5838830fd01d2e7e2ebe998bc3L4): Updated the `date` metadata to align with the autosave version's timestamp.
* [`_drafts/about-using-test-doubles-in-tests740-revision-v1-Using-Test-Doubles-in-tests.md`](diffhunk://#diff-f8b2fdcde0cd597a34b1bf726c0a47019c743bf06e81046b0eb60c18040baa55L4): Corrected the `date` field for the revision version of this draft.

### Updates to pages:

* [`_pages/about.md`](diffhunk://#diff-868de1bb8db54b4c403c8580345fe9324652dd4646a22b348d6bfc1eeb30c46aL4): Fixed the `date` metadata for the "About me" page to ensure accurate historical data.

### Updates to posts:

* [`_posts/2006-05-25-introducing-myself.md`](diffhunk://#diff-5ae88e5c618b31c35fe79ec91d9b72bd0089af159e98c152238bd6c2009cae11L4): Updated the `date` field for the "Introducing myself" post to match the original publication date.
* [`_posts/2006-06-13-ant-could-not-find-the-main-class-program-will-exit.md`](diffhunk://#diff-aa13f1f55bcdbb2ee1f6ef6c0b6caad8e2d92946330f664f5da4ae46433592b9L4): Corrected the `date` metadata for this post to reflect the proper timestamp.