### PR TITLE
fix(pagination): Correct pagination path format and update remote theme version

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@
 # https://mmistakes.github.io/minimal-mistakes/docs/quick-start-guide/#installing-the-theme
 
 #theme                  : "minimal-mistakes-jekyll"
-remote_theme           : "mmistakes/minimal-mistakes"
+remote_theme           : "mmistakes/minimal-mistakes@4.27.1"
 minimal_mistakes_skin    : "dark" # "air", "aqua", "contrast", "dark", "dirt", "neon", "mint", "plum", "sunrise"
 
 # Site Settings
@@ -231,7 +231,7 @@ permalinks:
 
 # Pagination with jekyll-paginate
 paginate: 5 # amount of posts to show
-paginate_path: /page/:num/
+paginate_path: /page:num/
 
 # Pagination with jekyll-paginate-v2
 # See https://github.com/sverrirs/jekyll-paginate-v2/blob/master/README-GENERATOR.md#site-configuration


### PR DESCRIPTION
This pull request updates the `_config.yml` file to improve theme versioning and correct permalink configuration.

Theme version update:

* Changed the `remote_theme` setting to specify version `4.27.1` of the `mmistakes/minimal-mistakes` theme, ensuring compatibility and stability. (`[_config.ymlL14-R14](diffhunk://#diff-ecec67b0e1d7e17a83587c6d27b6baaaa133f42482b07bd3685c77f34b62d883L14-R14)`)

Permalink configuration:

* Updated the `paginate_path` setting to remove the slash before `:num`, aligning with the expected URL structure. (`[_config.ymlL234-R234](diffhunk://#diff-ecec67b0e1d7e17a83587c6d27b6baaaa133f42482b07bd3685c77f34b62d883L234-R234)`)